### PR TITLE
Remove public submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.hugo_build.lock
 /jekyll-export/_posts/contact
 /jekyll-export/_posts/about
+/public

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "public"]
-	path = public
-	url = git@github.com:end2endzone/end2endzone.github.io.git
 [submodule "themes/pacollins.hugo-future-imperfect-slim"]
 	path = themes/pacollins.hugo-future-imperfect-slim
 	url = https://github.com/pacollins/hugo-future-imperfect-slim.git


### PR DESCRIPTION
Removed `public` directory submodule in preparation of using Github Actions to automatically push update to the directory. The directory was a submodule which is annoying when not wanting to create diffs while editing site.